### PR TITLE
Add basic CI with flake8 and pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest
+      - name: Lint with flake8
+        run: flake8
+      - name: Test with pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Repositorio de fórmulas para ETL y análisis de datos
+![CI](https://github.com/OWNER/Funciones-Data/actions/workflows/ci.yml/badge.svg)
 
-Este proyecto agrupa funciones reutilizables para manipulación y exploración de 
+Este proyecto agrupa funciones reutilizables para manipulación y exploración de
 datos con **pandas**. Las utilidades están organizadas en el paquete `formulas` y
 se acompañan de algunos notebooks de ejemplo.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies, run flake8 and pytest
- show workflow status badge in README

## Testing
- `flake8` *(fails: blank line at end of file, line too long, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c67c3566c832285019d07f4e69303