### PR TITLE
Add pyproject and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,16 @@ para tareas habituales.
 
 ## Instalación
 
-1. Clona este repositorio.
-2. Instala las dependencias:
+Instala la librería directamente con pip:
 
 ```bash
-pip install -r requirements.txt
+pip install formulas
+```
+
+Si prefieres instalarla desde el código fuente:
+
+```bash
+pip install .
 ```
 
 ## Uso rápido

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "formulas"
+version = "0.1.0"
+description = "Funciones reutilizables para ETL y análisis de datos."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE" }
+dependencies = [
+    "pandas",
+    "openpyxl",
+    "sqlalchemy",
+    "seaborn",
+    "matplotlib",
+    "plotly",
+    "scikit-learn",
+    "chardet",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
+from pathlib import Path
 from setuptools import setup, find_packages
+
+README = Path(__file__).with_name("README.md").read_text(encoding="utf-8")
 
 setup(
     name="formulas",
     version="0.1.0",
+    description="Funciones reutilizables para ETL y análisis de datos.",
+    long_description=README,
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     install_requires=[line.strip() for line in open("requirements.txt")],
 )


### PR DESCRIPTION
## Summary
- add PEP 621 `pyproject.toml` with project metadata and dependencies
- reference README as long description in `setup.py`
- document `pip install` usage in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c67d23bb483228e06547c53e7487b