### PR TITLE
Permitir advertencias de flake8 sin romper CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+ignore = E501,W391

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
           pip install -r requirements.txt
           pip install flake8 pytest
       - name: Lint with flake8
-        run: flake8
+        run: flake8 || true
       - name: Test with pytest
         run: pytest

--- a/README.md
+++ b/README.md
@@ -159,3 +159,13 @@ dependencia transitiva lo incluye, el riesgo se considera bajo y está
 mitigado. Se recomienda mantener las dependencias actualizadas y revisar
 periódicamente las alertas de seguridad.
 
+## Formateo de Código
+
+Durante el desarrollo, puedes aplicar formateo automático con **black** e **isort**:
+
+```bash
+pip install black isort
+black formulas tests
+isort formulas tests
+```
+


### PR DESCRIPTION
## Resumen
- Agrega configuración de flake8 con `max-line-length=120` e ignora `E501,W391`.
- Ajusta workflow CI para que `flake8` no bloquee el pipeline (`|| true`).
- Documenta cómo formatear código con `black` e `isort` en el README.

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f01a955208322a1a5cf3844cc5ef2