### PR TITLE
chore: add dependabot and security checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    rebase-strategy: "auto"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:
@@ -22,13 +23,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install flake8 pytest pip-audit
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_CONFIG: ".gitleaks.toml"      # opcional si existe
+          # GITLEAKS_ARGS: "--redact --verbose"    # opcional
       - name: Lint with flake8
         run: flake8 || true
       - name: Test with pytest
         run: pytest
       - name: Dependency security audit
         run: pip-audit -r requirements.txt --strict
-      - name: Scan for secrets with gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          args: --no-color

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "PlanifitAI secret rules (mínimo)"
+[allowlist]
+description = "Archivos permitidos (tests/docs)"
+regexes = [
+  '''\.secrets\.baseline$''',
+  '''tests?/.*\.(json|txt|ya?ml|md)$''',
+  '''README\.md$'''
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas
 openpyxl
-sqlalchemy
+SQLAlchemy==2.0.43      # pinned for MVP stability
 seaborn
 matplotlib
 plotly


### PR DESCRIPTION
## Summary
- enable Dependabot weekly pip checks
- enforce gitleaks scanning in CI
- pin SQLAlchemy for stability

## Testing
- `pip-audit -r requirements.txt --strict`
- `pytest -q`
- `python -m pre_commit run --all-files` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `python -m compileall app` *(fails: Can't list 'app')*
- `gitleaks detect --no-color --source . --config .gitleaks.toml`


------
https://chatgpt.com/codex/tasks/task_e_689f0653bf34832288f68efece38a871